### PR TITLE
Move initialisation to constructor in Confetti.js

### DIFF
--- a/confetti.js
+++ b/confetti.js
@@ -17,9 +17,6 @@ class Confetti extends Component {
       this._yAnimation = new Animated.Value(0);
       this.color = this.randomColor(this.props.colors);
       this.left = this.randomValue(0, windowWidth);
-  }
-
-  componentWillMount() {
       let rotationOutput = this.randomValue(-220, 220) + 'deg';
       this._rotateAnimation = this._yAnimation.interpolate({
         inputRange: [0, windowHeight / 2, windowHeight],


### PR DESCRIPTION
In React 16.4 `componentWillMount` is one of the 3 deprecated methods as per: https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html. I propose removing its use in favour of using the constructor.

The blogpost gives an example where they recommend refactoring a `setState` call in `componentWillMount` to state initialisation in the constructor or a property initialiser: https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#initializing-state

`componentWillMount` has always fired before the first render in React, and this case we would get a red screen if `this._rotateAnimation` and `this._xAnimation` were not initialised before the first render.

As with moving the `setState` call to a simple initialisation in the constructor, it is also safe for us to move the initialisation of the `rotateAnimation` and `xAnimation` Animated values to the constructor from `componentWillMount`.