### PR TITLE
Uptick version number on package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-confetti",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Raining confetti made with react native animations",
   "main": "confettiView.js",
   "repository": {


### PR DESCRIPTION
NPM has not picked up the merged in changes from back in February, I believe this is due to the version number not being upticked in that PR, so NPM is caching the older repo.